### PR TITLE
fix: bring react peerDependency definition inline with readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">= 16.8.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",


### PR DESCRIPTION
While this package does work with react@17 an install with npm@7 currently fails, because of this closed range peer dependency definition.